### PR TITLE
fix: escape HYAS Insight widget values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) HYAS, 2022-2025
+   Copyright (c) HYAS, 2022-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: HYAS Insight
-Copyright (c) HYAS, 2022-2025
+Copyright (c) HYAS, 2022-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # HYAS Insight
 
-Publisher: HYAS \
-Connector Version: 1.3.1 \
-Product Vendor: HYAS \
-Product Name: HYAS Insight \
+Publisher: HYAS <br>
+Connector Version: 1.3.1 <br>
+Product Vendor: HYAS <br>
+Product Name: HYAS Insight <br>
 Minimum Product Version: 5.5.0
 
 This app implements investigative actions that return HYAS Insight Records for the given Indicators
@@ -18,40 +18,40 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[lookup commandcontrol domain](#action-lookup-commandcontrol-domain) - Perform this action to get the C2 Domain Lookup Data for HYAS Insight \
-[lookup commandcontrol email](#action-lookup-commandcontrol-email) - Perform this action to get the C2 Email address Lookup Data for HYAS Insight \
-[lookup commandcontrol ip](#action-lookup-commandcontrol-ip) - Perform this action to get the C2 IP Lookup Data for HYAS Insight \
-[lookup commandcontrol hash](#action-lookup-commandcontrol-hash) - Perform this action to get the C2 Hash Lookup Data for HYAS Insight \
-[lookup whois domain](#action-lookup-whois-domain) - Perform this action to get the Whois Domain Lookup Data for HYAS Insight \
-[lookup whois email](#action-lookup-whois-email) - Perform this action to get the Whois Email address Lookup Data for HYAS Insight \
-[lookup whois phone](#action-lookup-whois-phone) - Perform this action to get the Whois Phone number Lookup Data for HYAS Insight \
-[lookup dynamicdns email](#action-lookup-dynamicdns-email) - Perform this action to get the Dynamicdns Email address Lookup Data for HYAS Insight \
-[lookup dynamicdns ip](#action-lookup-dynamicdns-ip) - Perform this action to get the Dynamicdns IP address Lookup Data for HYAS Insight \
-[lookup dynamicdns domain](#action-lookup-dynamicdns-domain) - Perform this action to get the Dynamicdns Domain Lookup Data for HYAS Insight \
-[lookup sinkhole ip](#action-lookup-sinkhole-ip) - Perform this action to get the Sinkhole IP address Lookup Data for HYAS Insight \
-[lookup passivehash ip](#action-lookup-passivehash-ip) - Perform this action to get the Passivehash IP address Lookup Data for HYAS Insight \
-[lookup passivehash domain](#action-lookup-passivehash-domain) - Perform this action to get the Passivehash Domain Lookup Data for HYAS Insight \
-[lookup ssl certificate ip](#action-lookup-ssl-certificate-ip) - Perform this action to get the SSL Certificate Lookup Data for HYAS Insight \
-[lookup passivedns domain](#action-lookup-passivedns-domain) - Perform this action to get the Passivedns Domain Lookup Data for HYAS Insight \
-[lookup current whois domain](#action-lookup-current-whois-domain) - Perform this action to get the Whois current Domain Lookup Data for HYAS Insight \
-[lookup passivedns ip](#action-lookup-passivedns-ip) - Perform this action to get the Passivedns IP address Lookup Data for HYAS Insight \
-[lookup malware information hash](#action-lookup-malware-information-hash) - Perform this action to get the Malware Information Lookup Data for HYAS Insight \
-[lookup malware record hash](#action-lookup-malware-record-hash) - Perform this action to get the Malware Record hash Lookup Data for HYAS Insight \
-[lookup malware record ip](#action-lookup-malware-record-ip) - Perform this action to get the Malware Record IP address Lookup Data for HYAS Insight \
-[lookup malware record domain](#action-lookup-malware-record-domain) - Perform this action to get the Malware Record Domain Lookup Data for HYAS Insight \
-[lookup os indicator hash](#action-lookup-os-indicator-hash) - Perform this action to get the OS Indicator Lookup Data for HYAS Insight \
-[lookup ssl certificate hash](#action-lookup-ssl-certificate-hash) - Perform this action to get the SSL Certificate hash Lookup Data for HYAS Insight \
-[lookup ssl certificate domain](#action-lookup-ssl-certificate-domain) - Perform this action to get the SSL Certificate Domain Lookup Data for HYAS Insight \
-[lookup devicegeo ip](#action-lookup-devicegeo-ip) - Perform this action to get the Mobile Geolocation Information IP address Lookup Data for HYAS Insight \
-[lookup os indicator domain](#action-lookup-os-indicator-domain) - Perform this action to get the OS Indicator Domain Lookup Data for HYAS Insight \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[lookup commandcontrol domain](#action-lookup-commandcontrol-domain) - Perform this action to get the C2 Domain Lookup Data for HYAS Insight <br>
+[lookup commandcontrol email](#action-lookup-commandcontrol-email) - Perform this action to get the C2 Email address Lookup Data for HYAS Insight <br>
+[lookup commandcontrol ip](#action-lookup-commandcontrol-ip) - Perform this action to get the C2 IP Lookup Data for HYAS Insight <br>
+[lookup commandcontrol hash](#action-lookup-commandcontrol-hash) - Perform this action to get the C2 Hash Lookup Data for HYAS Insight <br>
+[lookup whois domain](#action-lookup-whois-domain) - Perform this action to get the Whois Domain Lookup Data for HYAS Insight <br>
+[lookup whois email](#action-lookup-whois-email) - Perform this action to get the Whois Email address Lookup Data for HYAS Insight <br>
+[lookup whois phone](#action-lookup-whois-phone) - Perform this action to get the Whois Phone number Lookup Data for HYAS Insight <br>
+[lookup dynamicdns email](#action-lookup-dynamicdns-email) - Perform this action to get the Dynamicdns Email address Lookup Data for HYAS Insight <br>
+[lookup dynamicdns ip](#action-lookup-dynamicdns-ip) - Perform this action to get the Dynamicdns IP address Lookup Data for HYAS Insight <br>
+[lookup dynamicdns domain](#action-lookup-dynamicdns-domain) - Perform this action to get the Dynamicdns Domain Lookup Data for HYAS Insight <br>
+[lookup sinkhole ip](#action-lookup-sinkhole-ip) - Perform this action to get the Sinkhole IP address Lookup Data for HYAS Insight <br>
+[lookup passivehash ip](#action-lookup-passivehash-ip) - Perform this action to get the Passivehash IP address Lookup Data for HYAS Insight <br>
+[lookup passivehash domain](#action-lookup-passivehash-domain) - Perform this action to get the Passivehash Domain Lookup Data for HYAS Insight <br>
+[lookup ssl certificate ip](#action-lookup-ssl-certificate-ip) - Perform this action to get the SSL Certificate Lookup Data for HYAS Insight <br>
+[lookup passivedns domain](#action-lookup-passivedns-domain) - Perform this action to get the Passivedns Domain Lookup Data for HYAS Insight <br>
+[lookup current whois domain](#action-lookup-current-whois-domain) - Perform this action to get the Whois current Domain Lookup Data for HYAS Insight <br>
+[lookup passivedns ip](#action-lookup-passivedns-ip) - Perform this action to get the Passivedns IP address Lookup Data for HYAS Insight <br>
+[lookup malware information hash](#action-lookup-malware-information-hash) - Perform this action to get the Malware Information Lookup Data for HYAS Insight <br>
+[lookup malware record hash](#action-lookup-malware-record-hash) - Perform this action to get the Malware Record hash Lookup Data for HYAS Insight <br>
+[lookup malware record ip](#action-lookup-malware-record-ip) - Perform this action to get the Malware Record IP address Lookup Data for HYAS Insight <br>
+[lookup malware record domain](#action-lookup-malware-record-domain) - Perform this action to get the Malware Record Domain Lookup Data for HYAS Insight <br>
+[lookup os indicator hash](#action-lookup-os-indicator-hash) - Perform this action to get the OS Indicator Lookup Data for HYAS Insight <br>
+[lookup ssl certificate hash](#action-lookup-ssl-certificate-hash) - Perform this action to get the SSL Certificate hash Lookup Data for HYAS Insight <br>
+[lookup ssl certificate domain](#action-lookup-ssl-certificate-domain) - Perform this action to get the SSL Certificate Domain Lookup Data for HYAS Insight <br>
+[lookup devicegeo ip](#action-lookup-devicegeo-ip) - Perform this action to get the Mobile Geolocation Information IP address Lookup Data for HYAS Insight <br>
+[lookup os indicator domain](#action-lookup-os-indicator-domain) - Perform this action to get the OS Indicator Domain Lookup Data for HYAS Insight <br>
 [lookup os indicator ip](#action-lookup-os-indicator-ip) - Perform this action to get the OS Indicator Lookup Data for IP address HYAS Insight
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -66,7 +66,7 @@ No Output
 
 Perform this action to get the C2 Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -91,7 +91,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the C2 Email address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -116,7 +116,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the C2 IP Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -141,7 +141,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the C2 Hash Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -166,7 +166,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Whois Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -191,7 +191,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Whois Email address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -216,7 +216,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Whois Phone number Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -242,7 +242,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Dynamicdns Email address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -267,7 +267,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Dynamicdns IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -292,7 +292,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Dynamicdns Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -317,7 +317,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Sinkhole IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -343,7 +343,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Passivehash IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -369,7 +369,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Passivehash Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -395,7 +395,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the SSL Certificate Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -420,7 +420,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Passivedns Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -446,7 +446,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Whois current Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -472,7 +472,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Passivedns IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -498,7 +498,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Malware Information Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -523,7 +523,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Malware Record hash Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -548,7 +548,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Malware Record IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -571,7 +571,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Malware Record Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -596,7 +596,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the OS Indicator Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -621,7 +621,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the SSL Certificate hash Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -647,7 +647,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the SSL Certificate Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -672,7 +672,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the Mobile Geolocation Information IP address Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -697,7 +697,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the OS Indicator Domain Lookup Data for HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -722,7 +722,7 @@ summary.total_objects_successful | numeric | | |
 
 Perform this action to get the OS Indicator Lookup Data for IP address HYAS Insight
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -745,7 +745,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) HYAS, 2022-2025
+# Copyright (c) HYAS, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasinsight.json
+++ b/hyasinsight.json
@@ -7,10 +7,10 @@
     "logo": "logo_hyasinsight.svg",
     "logo_dark": "logo_hyasinsight_dark.svg",
     "product_name": "HYAS Insight",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "HYAS",
-    "license": "Copyright (c) HYAS, 2022-2025",
+    "license": "Copyright (c) HYAS, 2022-2026",
     "app_version": "1.3.1",
     "utctime_updated": "2025-04-28T19:56:05.804130Z",
     "package_name": "phantom_hyasinsight",
@@ -2023,5 +2023,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/hyasinsight_connector.py
+++ b/hyasinsight_connector.py
@@ -1,6 +1,6 @@
 # File: hyasinsight_connector.py
 #
-# Copyright (c) HYAS, 2022-2025
+# Copyright (c) HYAS, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasinsight_consts.py
+++ b/hyasinsight_consts.py
@@ -1,6 +1,6 @@
 # File: hyasinsight_consts.py
 #
-# Copyright (c) HYAS, 2022-2025
+# Copyright (c) HYAS, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasinsight_display_view.html
+++ b/hyasinsight_display_view.html
@@ -15,7 +15,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: hyasinsight_display_view.html
-  Copyright (c) HYAS, 2022-2025
+  Copyright (c) HYAS, 2022-2026
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/hyasinsight_display_view.html
+++ b/hyasinsight_display_view.html
@@ -59,7 +59,7 @@
             <td>IP</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.ip }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -74,7 +74,7 @@
             <td>Domain</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['domain'],'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['domain'],'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.domain }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -89,7 +89,7 @@
             <td>Email</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['email'],'value': '{{ result.param.email }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['email'],'value': '{{ result.param.email|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.email }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -104,7 +104,7 @@
             <td>Hash</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['sha256'],'value': '{{ result.param.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['sha256'],'value': '{{ result.param.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.hash }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -119,7 +119,7 @@
             <td>Phone</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['phone'],'value': '{{ result.param.phone }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['phone'],'value': '{{ result.param.phone|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.phone }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -134,7 +134,7 @@
             <td>IP</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.ipv4 }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -149,7 +149,7 @@
             <td>IP</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['ipv6'],'value': '{{ result.param.ipv6 }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['ipv6'],'value': '{{ result.param.ipv6|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.devicegeo_ipv6 }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -226,7 +226,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ device_geo.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ device_geo.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ device_geo.ipv4 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -234,7 +234,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip','ipv6'], 'value': '{{ device_geo.ipv6 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip','ipv6'], 'value': '{{ device_geo.ipv6|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ device_geo.ipv6 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -308,7 +308,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ device_geo.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ device_geo.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ sinkhole.ipv4 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -352,7 +352,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivehash.domain }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivehash.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivehash.domain }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -407,7 +407,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivedns.domain }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivedns.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivedns.domain }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -457,7 +457,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ip_ip }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ip_ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivedns.ip_ip }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -477,7 +477,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ip_isp_ip_address }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ip_isp_ip_address|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivedns.ip_isp_ip_address }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -497,7 +497,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivedns.ipv4 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -505,7 +505,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ipv6 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.ipv6|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ passivedns.ipv6 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -566,7 +566,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.created_ip }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.created_ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ dynamicdns.created_ip }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -574,7 +574,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivedns.domain }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ passivedns.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ dynamicdns.domain }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -582,7 +582,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.domain_creator_ip }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ passivedns.domain_creator_ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ dynamicdns.domain_creator_ip }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -590,7 +590,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ passivedns.email }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ passivedns.email|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ dynamicdns.email }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -625,7 +625,7 @@
                       <tr>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.actor_ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.actor_ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.actor_ipv4 }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -633,7 +633,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.c2_domain }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.c2_domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.c2_domain }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -641,7 +641,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.c2_ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.c2_ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.c2_ip }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -649,7 +649,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ c2attribution.c2_url }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ c2attribution.c2_url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.c2_url }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -663,7 +663,7 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ c2attribution.email }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ c2attribution.email|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.email }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -671,14 +671,14 @@
                         </td>
                         <td>
                           <a href="javascript:;"
-                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.email_domain }}' }], 0, {{ container.id }}, null, false);">
+                             onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.email_domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                             {{ c2attribution.email_domain }}
                             &nbsp;
                             <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                           </a>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.referrer_domain }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ c2attribution.referrer_domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ c2attribution.referrer_domain }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -686,7 +686,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.referrer_ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ c2attribution.referrer_ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ c2attribution.referrer_ipv4 }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -694,7 +694,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ c2attribution.referrer_url }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ c2attribution.referrer_url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ c2attribution.referrer_url }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -702,7 +702,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ c2attribution.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ c2attribution.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ c2attribution.sha256 }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -807,7 +807,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ ssl_certificate.GeoISP }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ ssl_certificate.GeoISP|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ ssl_certificate.geo_isp_isp }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -821,7 +821,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ ssl_certificate.ip }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ ssl_certificate.ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ ssl_certificate.ip }}
                               &nbsp;
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -1005,14 +1005,14 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ whois.domain }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ whois.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.domain }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.abuse_emails }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.abuse_emails|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.abuse_emails }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1061,7 +1061,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.email }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.email|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.email }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1184,7 +1184,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ whois.domain }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ whois.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.domain }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1197,7 +1197,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.abuse_emails }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.abuse_emails|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.abuse_emails }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1246,7 +1246,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.email }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['email'], 'value': '{{ whois.email|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.email }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1277,7 +1277,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['phone'], 'value': '{{ whois.phone }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['phone'], 'value': '{{ whois.phone|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ whois.phone_phone }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1436,14 +1436,14 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ os.domain }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ os.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.domain }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ os.domain_2tld }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ os.domain_2tld|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.domain_2tld }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1456,14 +1456,14 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ os.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ os.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.ipv4 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ipv6'], 'value': '{{ os.ipv6 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ipv6'], 'value': '{{ os.ipv6|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.ipv6 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1494,14 +1494,14 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sha1'], 'value': '{{ os.sha1 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sha1'], 'value': '{{ os.sha1|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.sha1 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ os.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ os.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.sha256 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1514,7 +1514,7 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ os.source_url }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['url'], 'value': '{{ os.source_url|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ os.source_url }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1556,21 +1556,21 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ sample.domain }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ sample.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ sample.domain }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ sample.ipv4 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ip'], 'value': '{{ sample.ipv4|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ sample.ipv4 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['ipv6'], 'value': '{{ sample.ipv6 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['ipv6'], 'value': '{{ sample.ipv6|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ sample.ipv6 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
@@ -1583,14 +1583,14 @@
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sha1'], 'value': '{{ sample.sha1 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sha1'], 'value': '{{ sample.sha1|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ sample.sha1 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>
                           </td>
                           <td>
                             <a href="javascript:;"
-                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ sample.sha256 }}' }], 0, {{ container.id }}, null, false);">
+                               onclick="context_menu(this, [{'contains': ['sha256'], 'value': '{{ sample.sha256|escapejs }}' }], 0, {{ container.id }}, null, false);">
                               {{ sample.sha256 }}
                               <span class="fa fa-caret-down" style="font-size: smaller;"></span>
                             </a>

--- a/hyasinsight_view.py
+++ b/hyasinsight_view.py
@@ -1,6 +1,6 @@
 # File: hyasinsight_view.py
 #
-# Copyright (c) HYAS, 2022-2025
+# Copyright (c) HYAS, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-* - Updated connector development tooling and supported Python versions.
+* Updated connector development tooling and supported Python versions.
 * Escaped every caller- or API-controlled value embedded in widget JavaScript handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Updated connector development tooling and supported Python versions.
+* Escaped every caller- or API-controlled value embedded in widget JavaScript handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated connector development tooling and supported Python versions.


### PR DESCRIPTION
## Summary

- apply Django escapejs to every caller- or API-controlled value embedded in widget JavaScript handlers
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4
- declare supported Python 3.9 and 3.13 runtimes

## Tracking

- PAPP-38202
- PSAAS-30818
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- hosted pre-commit and compile: pending

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.